### PR TITLE
functions.sh: Pass -w argument to iptables

### DIFF
--- a/src/defaults.sh
+++ b/src/defaults.sh
@@ -35,6 +35,7 @@
 [ -z "$IPTABLES_BINARY" ] && IPTABLES_BINARY=$(which iptables)
 [ -z "$IP6TABLES" ] && IP6TABLES=ip6tables_wrapper
 [ -z "$IP6TABLES_BINARY" ] && IP6TABLES_BINARY=$(which ip6tables)
+[ -z "$IPTABLES_ARGS" ] && IPTABLES_ARGS="-w 1"
 
 
 # Try modprobe first, fall back to insmod

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -159,8 +159,8 @@ ipt() {
         esac
     done
 
-    SILENT=1 ${IPTABLES} "$@"
-    SILENT=1 ${IP6TABLES} "$@"
+    SILENT=1 ${IPTABLES} $IPTABLES_ARGS "$@"
+    SILENT=1 ${IP6TABLES} $IPTABLES_ARGS "$@"
 }
 
 


### PR DESCRIPTION
When starting concurrently with other users of iptables, the iptables
invocations can fail because it can't grab the shared xtables lock. Pass
the -w argument to iptables to wait instead of failing, which should
hopefully make things work better. Use a 1-second max wait time to avoid
hanging forever if something goes wrong.

Fixes #132.

Signed-off-by: Toke Høiland-Jørgensen <toke@toke.dk>