### PR TITLE
defaults.sh: Don't override INSMOD variable if it is already set

### DIFF
--- a/src/defaults.sh
+++ b/src/defaults.sh
@@ -39,7 +39,7 @@
 
 
 # Try modprobe first, fall back to insmod
-[ -z "$INSMOD" ] && INSMOD=$(which modprobe) || INSMOD=$(which insmod)
+[ -z "$INSMOD" ] && { INSMOD=$(which modprobe) || INSMOD=$(which insmod); }
 [ -z "$TARGET" ] && TARGET="5ms"
 [ -z "$IPT_MASK" ] && IPT_MASK="0xff" # to disable: set mask to 0xffffffff
 #sm: we need the functions above before trying to set the ingress IFB device


### PR DESCRIPTION
@SpareSimian noticed that sqm-scripts would always use 'insmod' to load
modules on CentOS even though modprobe was also available. @gordonmessmer
noticed that this was due to the way the shell chains '&&' and '||'
operators, which would evaluate the second assignment if the first
zero-length check fails. And since defaults.sh is included from both
'start-sqm' and the .qos scripts, this double-evaluation always happens on
non-OpenWrt installations.

Fix this by properly grouping the assignment operators so they are
evaluated together if the variable is unset.

Fixes #133.

Signed-off-by: Toke Høiland-Jørgensen <toke@toke.dk>